### PR TITLE
Django doesnt want leading backslashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VENV = .venv
 PYTHON_CMD = python3.11
 APP_NAME ?= baking-test
+QUAY_ORG ?= $(USER)
 
 venv_check:
 ifndef VIRTUAL_ENV
@@ -18,7 +19,7 @@ endif
 setup: venv_check
 	python -m pip install cookiecutter
 	rm -rf baking-test
-	cookiecutter . project_name=$(APP_NAME) --no-input
+	cookiecutter . project_name=$(APP_NAME) quay_org=$(QUAY_ORG) --no-input
 
 test: venv_check setup
 	cd baking-test && make -f Makefile test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install cookiecutter you can simply run:
 python3 -m pip install --user cookiecutter
 ```
 
-Once installed, you can generate your new project. You'll be asked the local project directory name and whether to initialize a git
+Once installed, you can generate your new project. You'll be asked the repo name, quay org name and whether to initialize a git
 repository or not.
 
 ```shell

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
     "project_name": "baking-test",
-    "initialize_git": "y"
+    "initialize_git": "y",
+    "quay_org": "cloudservices"
 }

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -39,7 +39,7 @@ else
 endif
 
 run: venv_check stop-db install start-db migrate
-	${PYTHON_CMD} manage.py runserver
+	${PYTHON_CMD} manage.py runserver 8080
 
 migrate: venv_check
 	${PYTHON_CMD} manage.py migrate

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -39,7 +39,7 @@ else
 endif
 
 run: venv_check stop-db install start-db migrate
-	${PYTHON_CMD} manage.py runserver 8080
+	${PYTHON_CMD} manage.py runserver
 
 migrate: venv_check
 	${PYTHON_CMD} manage.py migrate

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
@@ -36,7 +36,7 @@ if isClowderEnabled():
     # TODO: refactor into app-common lib
     try:
         API_PATH = [ x.apiPath for x in cfg.endpoints if x.app == APP_NAME ].pop()
-        API_PATH = API_PATH.strip('/')
+        API_PATH = API_PATH.lstrip('/')
     except IndexError:
         API_PATH = ""
 

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
@@ -36,6 +36,7 @@ if isClowderEnabled():
     # TODO: refactor into app-common lib
     try:
         API_PATH = [ x.apiPath for x in cfg.endpoints if x.app == APP_NAME ].pop()
+        API_PATH.strip('/')
     except IndexError:
         API_PATH = ""
 

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
@@ -35,8 +35,7 @@ if isClowderEnabled():
 
     # TODO: refactor into app-common lib
     try:
-        API_PATH = [ x.apiPath for x in cfg.endpoints if x.app == APP_NAME ].pop()
-        API_PATH = API_PATH.lstrip('/')
+        API_PATH = [ x.apiPath for x in cfg.endpoints if x.app == APP_NAME ].pop().lstrip('/')
     except IndexError:
         API_PATH = ""
 

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.project_name}}/settings.py
@@ -36,7 +36,7 @@ if isClowderEnabled():
     # TODO: refactor into app-common lib
     try:
         API_PATH = [ x.apiPath for x in cfg.endpoints if x.app == APP_NAME ].pop()
-        API_PATH.strip('/')
+        API_PATH = API_PATH.strip('/')
     except IndexError:
         API_PATH = ""
 


### PR DESCRIPTION
Django expects there to NOT be a leading `/` in the path.

This also adds an option to specify your Quay.io org during cookiecutter templating.