### PR TITLE
Fix Makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,19 +55,19 @@ pipeline {
             steps {
                 dir("${APP_NAME}") {
                     withVault([configuration: configuration, vaultSecrets: secrets]) {
-                        script {
-                            NAMESPACE = sh(returnStdout:true, script: '''
-                                make oc_login
-                                source .venv/bin/activate
-                                make bonfire_reserve_namespace
-                            ''').trim()
-                        }
-                        echo "Namespace reserved:${NAMESPACE}"
-                        sh """
-                            source .venv/bin/activate
-                            NAMESPACE=${NAMESPACE} make bonfire_deploy
-                            """
+                        sh 'make oc_login'
                     }
+                    script {
+                        NAMESPACE = sh(returnStdout:true, script: '''
+                            source .venv/bin/activate
+                            make bonfire_reserve_namespace
+                        ''').trim()
+                    }
+                    echo "Namespace reserved:${NAMESPACE}"
+                    sh """
+                        source .venv/bin/activate
+                        NAMESPACE=${NAMESPACE} make bonfire_deploy
+                    """
                 }
             }
         }

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -124,7 +124,7 @@ bonfire_process:
 		-p service/IMAGE=$(IMAGE) -p service/IMAGE_TAG=$(IMAGE_TAG) -n default
 
 bonfire_reserve_namespace:
-	@bonfire namespace reserve
+	@bonfire namespace reserve -f
 
 bonfire_release_namespace: namespace_check
 	bonfire namespace release $(NAMESPACE) -f
@@ -145,4 +145,4 @@ stop-db:
 	$(CONTAINER_ENGINE) stop $(APP_NAME)-db
 	$(CONTAINER_ENGINE) rm $(APP_NAME)-db
 oc_login:
-	oc login --token=${OC_LOGIN_TOKEN} --server=${OC_LOGIN_SERVER}
+	@oc login --token=${OC_LOGIN_TOKEN} --server=${OC_LOGIN_SERVER}


### PR DESCRIPTION
This fixes a bug introduced with #20 
- Fix a bug where the namespace will not be captured due to `oc login` output
- Forces namespace reservation to avoid collisions with future parallel PR runs.