### PR TITLE
add file needed for quay plugin in backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cookiecutter-backend-starter-app-python
+  annotations:
+    github.com/project-slug: RedHatInsights/cookiecutter-backend-starter-app-python
+spec:
+  type: other
+  lifecycle: stage
+  owner: my-group


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Engineering Developer Hub software catalog](http://localhost:7007).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).